### PR TITLE
Update Dockerfile to fix "Password: FAILED (Invalid Password)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM steamcmd/steamcmd:latest
+FROM steamcmd/steamcmd:ubuntu-22
 COPY steam_deploy.sh /root/steam_deploy.sh
 ENTRYPOINT ["/root/steam_deploy.sh"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This action assumes you are registered as a [partner](https://partner.steamgames
 
 #### 1. Create a Steam Build Account
 
-Create a specialised builder account that only has access to `Edit App Metadata` and `Publish App Changes To Steam`.
+Create a specialised builder account that only has access to `Edit App Metadata` and `Publish App Changes To Steam`,
+and permissions to edit your specific app.
 
 https://partner.steamgames.com/doc/sdk/uploading#Build_Account
 


### PR DESCRIPTION
The action has recently ceased to work properly in conjunction with the `configVdf` option, much like the upstream repository game-ci/steam-deploy. See discussion in game-ci/steam-deploy#62.

This PR simply merges the upstream changes from game-ci/steam-deploy#69. I did a careful merge to only update the relevant change in the Dockerfile (b1925dc3579687a251671df5020ddcb1e5ba7c0e), while rejecting the changes in the README (326a170face941318f5bc47b5d1c627eb5669759).

This minor change should reinstate full operability.