### PR TITLE
Enhance deployment workflow and update Workshop item metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 ## IMPORTANT NOTICE
 
-Versions v1, v2 and v3 of this action have been disabled due to a potential security risk. Please upgrade to v4, which contains a fix for the issue.
+Versions v1, and v1.0.1 of this action have been disabled due to a potential security risk. Please upgrade to v2, which contains a fix for the issue.
 
 If you have previously used this action with the upload directory (`path` parameter) pointed at the repository root (or a different directory containing a `.git` directory)
 please note that before v4 this action did not exclude the `.git` directory from the upload. If you are affected by this, you should check your uploaded workshop items for any `.git` directories,

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ An optional changenote to describe the update.
 
 #### previewFile
 
-Optional path to a preview image, relative to `path`, used to update the Workshop item's thumbnail. Omit to leave the item's current preview image unchanged (this is also the fallback behavior of upstream `steamcmd`/`workshop_build_item` when `previewfile` is absent from the manifest).
+Optional path to a preview image, relative to the **repository root** (not to `path`), used to update the Workshop item's thumbnail. Omit to leave the item's current preview image unchanged (this is also the fallback behavior of upstream `steamcmd`/`workshop_build_item` when `previewfile` is absent from the manifest). Resolved relative to the repo root rather than `path` because it's Workshop *listing* metadata, not part of the uploaded content -- it must stay reachable even when `path` points at a build-output subfolder that doesn't itself contain the preview image.
 
 #### visibility
 

--- a/README.md
+++ b/README.md
@@ -107,3 +107,7 @@ The path of the directory to be uploaded, relative to the repository root.
 #### changeNote
 
 An optional changenote to describe the update.
+
+#### previewFile
+
+Optional path to a preview image, relative to `path`, used to update the Workshop item's thumbnail. Omit to leave the item's current preview image unchanged (this is also the fallback behavior of upstream `steamcmd`/`workshop_build_item` when `previewfile` is absent from the manifest).

--- a/README.md
+++ b/README.md
@@ -111,3 +111,17 @@ An optional changenote to describe the update.
 #### previewFile
 
 Optional path to a preview image, relative to `path`, used to update the Workshop item's thumbnail. Omit to leave the item's current preview image unchanged (this is also the fallback behavior of upstream `steamcmd`/`workshop_build_item` when `previewfile` is absent from the manifest).
+
+#### visibility
+
+Optional. `0` (Public), `1` (FriendsOnly), `2` (Private), or `3` (Unlisted). Omit to leave the item's current visibility unchanged.
+
+#### title
+
+Optional Workshop item title. Omit to leave the item's current title unchanged.
+
+#### description
+
+Optional Workshop item description. Omit to leave the item's current description unchanged. Not escaped for embedded quotes -- avoid literal `"` characters in the value.
+
+Note: Workshop **tags** are not supported here -- `workshop_build_item`'s VDF manifest has no documented `tags` key (Valve's docs only reference `ISteamUGC::SetItemTags`/`AddItemKeyValueTag`, which aren't exposed through this manifest-based flow). Setting tags would need the separate Steamworks Web API, not `steamcmd`.

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,10 @@ inputs:
     required: false
     default: ''
     description: 'An optional changenote to describe the update.'
+  previewFile:
+    required: false
+    default: ''
+    description: 'Path to a preview image file, relative to `path`, used to update the Workshop item thumbnail. Omit to leave the item''s current preview image unchanged.'
 outputs:
   manifest:
     description: "The path to the generated manifest.vdf"
@@ -75,3 +79,4 @@ runs:
     stagingPath: ${{ inputs.stagingPath }}
     concurrentStaging: ${{ inputs.concurrentStaging }}
     verbosity: ${{ inputs.verbosity }}
+    previewFile: ${{ inputs.previewFile }}

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,18 @@ inputs:
     required: false
     default: ''
     description: 'Path to a preview image file, relative to `path`, used to update the Workshop item thumbnail. Omit to leave the item''s current preview image unchanged.'
+  visibility:
+    required: false
+    default: ''
+    description: 'Workshop item visibility: 0 (Public), 1 (FriendsOnly), 2 (Private), or 3 (Unlisted). Omit to leave the item''s current visibility unchanged.'
+  title:
+    required: false
+    default: ''
+    description: 'Workshop item title. Omit to leave the item''s current title unchanged.'
+  description:
+    required: false
+    default: ''
+    description: 'Workshop item description. Omit to leave the item''s current description unchanged. Not escaped for embedded quotes -- avoid literal `"` characters.'
 outputs:
   manifest:
     description: "The path to the generated manifest.vdf"
@@ -80,3 +92,6 @@ runs:
     concurrentStaging: ${{ inputs.concurrentStaging }}
     verbosity: ${{ inputs.verbosity }}
     previewFile: ${{ inputs.previewFile }}
+    visibility: ${{ inputs.visibility }}
+    title: ${{ inputs.title }}
+    description: ${{ inputs.description }}

--- a/steam_deploy.sh
+++ b/steam_deploy.sh
@@ -79,15 +79,28 @@ echo "#    Generating Item Manifest   #"
 echo "#################################"
 echo ""
 
-cat << EOF > "manifest.vdf"
-"workshopitem"
+previewFilePath=""
+if [ -n "${previewFile:-}" ]; then
+    previewFilePath="$contentroot/$previewFile"
+    if [ ! -f "$previewFilePath" ]; then
+        echo "::error::previewFile '$previewFile' not found at $previewFilePath"
+        exit 1
+    fi
+    echo "Using preview image: $previewFilePath"
+fi
+
 {
-    "appid" "$appId"
-    "publishedfileid" "$itemId"
-    "contentfolder" "$stagingPath"
-    "changenote" "$changeNote"
-}
-EOF
+    echo "\"workshopitem\""
+    echo "{"
+    echo "    \"appid\" \"$appId\""
+    echo "    \"publishedfileid\" \"$itemId\""
+    echo "    \"contentfolder\" \"$stagingPath\""
+    echo "    \"changenote\" \"$changeNote\""
+    if [ -n "$previewFilePath" ]; then
+        echo "    \"previewfile\" \"$previewFilePath\""
+    fi
+    echo "}"
+} > "manifest.vdf"
 
 cat manifest.vdf
 echo ""

--- a/steam_deploy.sh
+++ b/steam_deploy.sh
@@ -89,6 +89,11 @@ if [ -n "${previewFile:-}" ]; then
     echo "Using preview image: $previewFilePath"
 fi
 
+if [ -n "${visibility:-}" ] && ! [[ "$visibility" =~ ^[0-3]$ ]]; then
+    echo "::error::visibility '$visibility' is invalid. Must be 0 (Public), 1 (FriendsOnly), 2 (Private), or 3 (Unlisted)."
+    exit 1
+fi
+
 {
     echo "\"workshopitem\""
     echo "{"
@@ -98,6 +103,15 @@ fi
     echo "    \"changenote\" \"$changeNote\""
     if [ -n "$previewFilePath" ]; then
         echo "    \"previewfile\" \"$previewFilePath\""
+    fi
+    if [ -n "${visibility:-}" ]; then
+        echo "    \"visibility\" \"$visibility\""
+    fi
+    if [ -n "${title:-}" ]; then
+        echo "    \"title\" \"$title\""
+    fi
+    if [ -n "${description:-}" ]; then
+        echo "    \"description\" \"$description\""
     fi
     echo "}"
 } > "manifest.vdf"

--- a/steam_deploy.sh
+++ b/steam_deploy.sh
@@ -81,7 +81,12 @@ echo ""
 
 previewFilePath=""
 if [ -n "${previewFile:-}" ]; then
-    previewFilePath="$contentroot/$previewFile"
+    # Resolved relative to the action's invocation directory (repo root),
+    # not $contentroot/$rootPath -- previewFile is Workshop *listing* metadata,
+    # not part of the uploaded content, so it must stay reachable even when
+    # rootPath points at a subfolder (e.g. a "Contents/" build output dir)
+    # that doesn't itself contain the preview image.
+    previewFilePath="$(pwd)/$previewFile"
     if [ ! -f "$previewFilePath" ]; then
         echo "::error::previewFile '$previewFile' not found at $previewFilePath"
         exit 1


### PR DESCRIPTION
Added all parameters supported via [SteamCmd Integration](https://partner.steamgames.com/doc/features/workshop/implementation#SteamCmd):

```json
"workshopitem"
{
 "appid" "480"
 "publishedfileid" "5674"
 "contentfolder" "D:\\Content\\workshopitem"
 "previewfile" "D:\\Content\\preview.jpg"
 "visibility" "0"
 "title" "Team Fortress Green Hat"
 "description" "A green hat for Team Fortress"
 "changenote" "Version 1.2"
}
```

It was useful for my use case, where I needed to update a _preview.png_ image from a workshop app.

Since I made the changes based on your fork, feel free to add them to your action if you'd like.